### PR TITLE
Use git cherry-pick instead of patch files

### DIFF
--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -4,10 +4,12 @@ import path from "path";
 import simpleGit, { SimpleGit } from "simple-git";
 import tmp from "tmp";
 
-import { applyPatches } from "./git";
+import { applyPatches, patchLocation } from "./git";
 
 let dirObj: tmp.DirResult;
+let upstreamDirObj: tmp.DirResult;
 let gitObj: SimpleGit;
+let upstreamGitObj: SimpleGit;
 
 beforeEach(async () => {
   dirObj = tmp.dirSync({ keep: true, unsafeCleanup: true });
@@ -19,100 +21,61 @@ beforeEach(async () => {
       fs.writeFileSync(path.join(dirObj.name, "message.txt"), "Hello Raleigh!\n");
       await gitObj.add("message.txt").commit("Add a welcome message");
     });
+
+  upstreamDirObj = tmp.dirSync({ keep: true, unsafeCleanup: true });
+  upstreamGitObj = simpleGit(upstreamDirObj.name);
+  await upstreamGitObj
+    .init()
+    .branch(["-m", "main"])
+    .then(async () => {
+      fs.writeFileSync(path.join(upstreamDirObj.name, "message.txt"), "Hello Raleigh!\n");
+      await upstreamGitObj.add("message.txt").commit("Add a welcome message");
+    });
 });
 
 afterEach(() => {
   dirObj.removeCallback();
+  upstreamDirObj.removeCallback();
 });
 
 test("applyPatches with two valid patches and an empty patch", async () => {
-  const patches = [
-    `
-From d09f72f1d6729528c62bc0df5a70d635d47907bb Mon Sep 17 00:00:00 2001
-From: mprahl <mprahl@users.noreply.github.com>
-Date: Wed, 1 Jun 2022 10:39:29 -0400
-Subject: [PATCH] Add the state to the message
+  const patchLocations: Array<patchLocation> = [];
+  fs.writeFileSync(path.join(upstreamDirObj.name, "message.txt"), "Hello Raleigh, NC!\n");
+  await upstreamGitObj.add("message.txt").commit("Add the state to the message");
+  patchLocations.push({ head: await upstreamGitObj.revparse(["HEAD"]), numCommits: 1 });
+  fs.writeFileSync(path.join(upstreamDirObj.name, "message.txt"), "Hello Raleigh, NC, USA!\n");
+  await upstreamGitObj.add("message.txt").commit("Add the country to the message");
+  fs.writeFileSync(path.join(upstreamDirObj.name, "message.txt"), "Hello Raleigh, NC, United States of America!\n");
+  await upstreamGitObj.add("message.txt").commit("Spell out the country in the message");
+  patchLocations.push({ head: await upstreamGitObj.revparse(["HEAD"]), numCommits: 2 });
+  await upstreamGitObj.raw(["commit", "--allow-empty", "-m", "Empty commit"]);
+  patchLocations.push({ head: await upstreamGitObj.revparse(["HEAD"]), numCommits: 1 });
 
----
- message.txt | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
-diff --git a/message.txt b/message.txt
-index 1bfd7cc..382ca18 100644
---- a/message.txt
-+++ b/message.txt
-@@ -1 +1 @@
--Hello Raleigh!
-+Hello Raleigh, NC!
--- 
-2.35.3
-    `,
-    `
-From f4daacd4a0c9c2a8cf12b64ddf77c4302e628917 Mon Sep 17 00:00:00 2001
-From: mprahl <mprahl@users.noreply.github.com>
-Date: Wed, 1 Jun 2022 10:43:47 -0400
-Subject: [PATCH] Add the country to the message
-
----
- message.txt | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
-diff --git a/message.txt b/message.txt
-index 382ca18..cea7f00 100644
---- a/message.txt
-+++ b/message.txt
-@@ -1 +1 @@
--Hello Raleigh, NC!
-+Hello Raleigh, NC, USA!
--- 
-2.35.3
-    `,
-    "",
-  ];
-
-  expect(await applyPatches("file://" + dirObj.name, "main", "main-with-patch", patches)).toBe(true);
+  await expect(
+    applyPatches("file://" + dirObj.name, "file://" + upstreamDirObj.name, "main", "main-with-patch", patchLocations),
+  ).resolves.not.toThrowError();
   await gitObj.checkout("main-with-patch").then(() => {
     const textOutput = fs.readFileSync(path.join(dirObj.name, "message.txt"));
-    expect(textOutput.toString()).toEqual("Hello Raleigh, NC, USA!\n");
+    expect(textOutput.toString()).toEqual("Hello Raleigh, NC, United States of America!\n");
   });
 });
 
-test("applyPatches with a patch that doesn't change the Git history", async () => {
-  fs.writeFileSync(path.join(dirObj.name, "message.txt"), "Hello\nRaleigh, NC!\n");
+test("applyPatches invalid patch", async () => {
+  fs.writeFileSync(path.join(dirObj.name, "message.txt"), "Hello\nRaleigh, North Carolina!\n");
   await gitObj.add("message.txt").commit("Add the state");
 
-  const patch = await gitObj.raw(["format-patch", "HEAD~1", "--stdout"]);
+  fs.writeFileSync(path.join(upstreamDirObj.name, "message.txt"), "Hello\nRaleigh, NC!\n");
+  await upstreamGitObj.add("message.txt").commit("Add the state");
 
-  expect(await applyPatches("file://" + dirObj.name, "main", "main-with-patch", [patch])).toBe(false);
-});
+  const patchLocations = [{ head: await upstreamGitObj.revparse(["HEAD"]), numCommits: 1 }];
 
-test("applyPatches invalid patch", async () => {
-  const patches = [
-    `
-From f4daacd4a0c9c2a8cf12b64ddf77c4302e628917 Mon Sep 17 00:00:00 2001
-From: mprahl <mprahl@users.noreply.github.com>
-Date: Wed, 1 Jun 2022 10:43:47 -0400
-Subject: [PATCH] Add the country to the message
-
----
- message.txt | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
-diff --git a/message.txt b/message.txt
-index 382ca18..cea7f00 100644
---- a/message.txt
-+++ b/message.txt
-@@ -1 +1 @@
--Hello Raleigh, NC!
-+Hello Raleigh, NC, USA!
--- 
-2.35.3
-    `,
-  ];
-
-  await expect(applyPatches("file://" + dirObj.name, "main", "main-with-patch", patches)).rejects.toThrow();
+  await expect(
+    applyPatches("file://" + dirObj.name, "file://" + upstreamDirObj.name, "main", "main-with-patch", patchLocations),
+  ).rejects.toThrow();
 });
 
 test("applyPatches no input patches", async () => {
-  await expect(applyPatches("file://" + dirObj.name, "main", "main-with-patch", [])).rejects.toThrow();
+  await expect(
+    applyPatches("file://" + dirObj.name, "file://" + upstreamDirObj.name, "main", "main-with-patch", []),
+  ).rejects.toThrow();
 });

--- a/src/git.ts
+++ b/src/git.ts
@@ -4,56 +4,58 @@ import path from "path";
 import simpleGit from "simple-git";
 import tmp from "tmp";
 
+// patchLocation represents the head (commit hash of the start of the patch) and the number of commits as part of the
+// patch.
+export type patchLocation = {
+  head: string;
+  numCommits: number;
+};
+
 /**
- * Apply the input Git patches and push the changes.
+ * Apply the input Git patches using `git cherry-pick` and push the changes.
  * @param {string} remoteURL the Git URL to clone from and push to. It should include any required authentication.
+ * @param {string} upstreamRemoteURL the upstream Git URL to the repo to cherry-pick from.
  * @param {string} sourceBranch the branch to use as a base for applying the patches.
  * @param {string} targetBranch the branch to push applied patches to.
- * @param {Array<string>} patches the array of Git patch strings to apply.
- * @return {Promise<boolean>} a promise that resolves to a boolean determining if the patches actually affected the Git
- *   history and were pushed. This will be false if the patches are diffs that are already applied on the target branch.
- *   This rejects when there is a Git error such as a patch not applying.
+ * @param {Array<patchLocation>} patchLocations the array of patch locations (i.e. patch commit HEAD and number of
+ *   commits) to apply.
+ * @return {Promise<void>} a promise that resolves to nothing.
  */
 export async function applyPatches(
   remoteURL: string,
+  upstreamRemoteURL: string,
   sourceBranch: string,
   targetBranch: string,
-  patches: Array<string>,
-): Promise<boolean> {
-  if (!patches.length) {
+  patchLocations: Array<patchLocation>,
+) {
+  if (!patchLocations.length) {
     throw new Error("One or more patches are required");
   }
 
   const dirObj = tmp.dirSync({ keep: true, unsafeCleanup: true });
   try {
-    const patchFiles: Array<string> = [];
-    patches.map((patch, i) => {
-      if (patch) {
-        const patchPath = path.join(dirObj.name, `patch${i + 1}.patch`);
-        fs.writeFileSync(patchPath, patches[i]);
-        patchFiles.push(patchPath);
-      }
-    });
-
-    const gitPath = path.join(dirObj.name, "repo");
-    fs.mkdirSync(gitPath);
     // These method calls, when chained together, will run serially. Any failure will cause
     // the chain to stop.
-    const git = simpleGit(gitPath);
-    await git.clone(remoteURL, gitPath).checkoutBranch(targetBranch, `origin/${sourceBranch}`);
+    const git = simpleGit(dirObj.name);
+    await git
+      .clone(remoteURL, dirObj.name)
+      .checkoutBranch(targetBranch, `origin/${sourceBranch}`)
+      .remote(["add", "upstream", upstreamRemoteURL])
+      .fetch(["upstream", "--prune"]);
 
-    const originalHead = await git.revparse(["HEAD"]);
-
-    await Promise.all(patchFiles.map((patchFile) => git.raw(["am", "-3", patchFile])));
-
-    const newHead = await git.revparse(["HEAD"]);
-    if (originalHead === newHead) {
-      return false;
-    }
+    await Promise.all(
+      patchLocations.map((p) =>
+        git.raw([
+          "cherry-pick",
+          "-x",
+          `${p.head}~${p.numCommits}..${p.head}`,
+          "--allow-empty",
+          "--keep-redundant-commits",
+        ]),
+      ),
+    );
 
     await git.push(["origin", "HEAD"]);
-
-    return true;
   } finally {
     dirObj.removeCallback();
   }


### PR DESCRIPTION
This allows the option of `-x` in `git cherry-pick` so that the original
upstream commit hash is recorded in the forked repo's commit message.

This will allow easy searching of an upstream commit in the fork.