### PR TITLE
Consider all PR check runs and commit statuses before merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,36 @@ closing the GitHub issue signals to Magic Mirror that the failed sync was manual
 Installing Magic Mirror on a particular GitHub repository indicates that it should be synced with upstream. Additional
 configuration as described in the [Configuration](#configuration) section is still required.
 
+## GitHub Repository Configuration
+
+### Upstream Repositories
+
+The upstream repository must use the "rebase" merge method on all pull-requests (PRs) or require that all PRs only
+contain a single commit. The reason is that Magic Mirror is unable to detect which merge method was used on the upstream
+PR.
+
+### Forked Repositories
+
+Forked repositories must have the following configured:
+
+- [Required status checks before merging](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#require-status-checks-before-merging)
+  if you'd like for CI to pass before the cherry-pick PR is merged.
+- [Rebase merges](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/about-merge-methods-on-github#rebasing-and-merging-your-commits)
+  are enabled.
+- Merges must not require an
+  [approval](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#require-pull-request-reviews-before-merging).
+- It's also recommended to enable
+  [automatic deletion of branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-the-automatic-deletion-of-branches)
+  since Magic Mirror works by creating temporary branches on the forked repository.
+
 ### Permissions
 
 The GitHub App requires the following repository permissions:
 
 - [Checks](https://docs.github.com/en/rest/overview/permissions-required-for-github-apps#permission-on-checks) read
   access. This is needed to verify that the CI on a PR has passed.
+- [Commit statuses](https://docs.github.com/en/rest/overview/permissions-required-for-github-apps#permission-on-statuses)
+  read access. This is needed to verify that the CI on a PR has passed.
 - [Contents](https://docs.github.com/en/rest/overview/permissions-required-for-github-apps#permission-on-contents) read
   and write access. This is needed so that repository can be cloned and a branch created with the cherry picked upstream
   commits.
@@ -34,9 +58,10 @@ The GitHub App requires the following repository permissions:
 
 The GitHub app requires being subscribed to the following events:
 
-- [Check suite](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#check_suite)
+- [Check run](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#check_suite)
 - [Issues](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#issues)
 - [Pull request](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request)
+- [Status](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#status)
 
 ## Configuration
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@octokit/auth-app": "^3.6.1",
         "@octokit/rest": "^18.12.0",
+        "@octokit/webhooks-types": "^5.8.0",
         "probot": "^12.2.4",
         "simple-git": "^3.7.1",
         "sqlite3": "^5.0.8",
@@ -2886,6 +2887,11 @@
       "integrity": "sha512-35cfQ4YWlnZnmZKmIxlGPUPLtbkF8lr/A/1Sk1eC0ddLMwQN06dOuLc+dI3YLQS+T+MoNt3DIQ0NynwgKPilig=="
     },
     "node_modules/@octokit/webhooks-types": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-5.8.0.tgz",
+      "integrity": "sha512-8adktjIb76A7viIdayQSFuBEwOzwhDC+9yxZpKNHjfzrlostHCw0/N7JWpWMObfElwvJMk2fY2l1noENCk9wmw=="
+    },
+    "node_modules/@octokit/webhooks/node_modules/@octokit/webhooks-types": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-5.7.1.tgz",
       "integrity": "sha512-zabCzfWvvquxDzj1lU7GhJQteACGfGXnHfROJD4A7LKhRjlkaggoSkE5cWQJJ6nW2t/UI51dSFrEA+A4mhqfPw=="
@@ -14573,6 +14579,13 @@
         "@octokit/webhooks-methods": "^2.0.0",
         "@octokit/webhooks-types": "5.7.1",
         "aggregate-error": "^3.1.0"
+      },
+      "dependencies": {
+        "@octokit/webhooks-types": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-5.7.1.tgz",
+          "integrity": "sha512-zabCzfWvvquxDzj1lU7GhJQteACGfGXnHfROJD4A7LKhRjlkaggoSkE5cWQJJ6nW2t/UI51dSFrEA+A4mhqfPw=="
+        }
       }
     },
     "@octokit/webhooks-methods": {
@@ -14581,9 +14594,9 @@
       "integrity": "sha512-35cfQ4YWlnZnmZKmIxlGPUPLtbkF8lr/A/1Sk1eC0ddLMwQN06dOuLc+dI3YLQS+T+MoNt3DIQ0NynwgKPilig=="
     },
     "@octokit/webhooks-types": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-5.7.1.tgz",
-      "integrity": "sha512-zabCzfWvvquxDzj1lU7GhJQteACGfGXnHfROJD4A7LKhRjlkaggoSkE5cWQJJ6nW2t/UI51dSFrEA+A4mhqfPw=="
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-5.8.0.tgz",
+      "integrity": "sha512-8adktjIb76A7viIdayQSFuBEwOzwhDC+9yxZpKNHjfzrlostHCw0/N7JWpWMObfElwvJMk2fY2l1noENCk9wmw=="
     },
     "@probot/get-private-key": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@octokit/auth-app": "^3.6.1",
     "@octokit/rest": "^18.12.0",
+    "@octokit/webhooks-types": "^5.8.0",
     "probot": "^12.2.4",
     "simple-git": "^3.7.1",
     "sqlite3": "^5.0.8",

--- a/src/fixtures/check_run.completed.json
+++ b/src/fixtures/check_run.completed.json
@@ -1,13 +1,14 @@
 {
   "action": "completed",
-  "check_suite": {
-    "id": 118578147,
-    "status": "completed",
+  "check_run": {
+    "head_sha": "db26c3e57ca3a959ca5aad62de7213c562f8c832",
     "conclusion": "success",
+    "name": "KinD tests (1.17, latest)",
     "pull_requests": [
       {
         "number": 5,
         "head": {
+          "ref": "changes",
           "sha": "ec26c3e57ca3a959ca5aad62de7213c562f8c821"
         },
         "base": {
@@ -18,11 +19,12 @@
       {
         "number": 6,
         "head": {
+          "ref": "changes",
           "sha": "db26c3e57ca3a959ca5aad62de7213c562f8c832"
         },
         "base": {
           "ref": "release-2.5",
-          "sha": "e85f852bd8fca8fcc58a9a2d6c842781e32a217a"
+          "sha": "f95f852bd8fca8fcc58a9a2d6c842781e32a215e"
         }
       }
     ]

--- a/src/fixtures/status.json
+++ b/src/fixtures/status.json
@@ -1,0 +1,11 @@
+{
+  "sha": "db26c3e57ca3a959ca5aad62de7213c562f8c832",
+  "context": "dco",
+  "state": "success",
+  "repository": {
+    "name": "config-policy-controller",
+    "owner": {
+      "login": "stolostron"
+    }
+  }
+}

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,4 +1,5 @@
 import { Octokit } from "@octokit/rest";
+import { Database, PendingPR, PRAction } from "./db";
 
 /**
  * Create a GitHub issue indicating that sync from upstream failed.
@@ -40,4 +41,68 @@ export async function createFailureIssue(
 
   const resp = await client.issues.create({ owner: org, repo: repo, title: title, body: body });
   return resp.data.number;
+}
+
+/**
+ * Get the required check names (statuses and check runs) for the branch.
+ * @param {Octokit} client the GitHub client to use that is authenticated as the GitHub installation.
+ * @param {string} organization the GitHub organization of the repository to check.
+ * @param {string} repoName the GitHub repository name of the repository to check.
+ * @param {string} branchName the GitHub branch name to check.
+ * @return {Promise<Set<string>>} a Promise that resolves to a set of required check names.
+ */
+export async function getRequiredChecks(
+  client: Octokit,
+  organization: string,
+  repoName: string,
+  branchName: string,
+): Promise<Set<string>> {
+  const branch = await client.repos.getBranch({ owner: organization, repo: repoName, branch: branchName });
+  if (!branch.data.protection.enabled || !branch.data.protection.required_status_checks) {
+    return new Set<string>();
+  }
+
+  return new Set(branch.data.protection.required_status_checks.contexts);
+}
+
+/**
+ * Merge the GitHub pull-request with the rebase merge method.
+ *
+ * If the PR cannot be merged, a GitHub issue is created to notify of the failure.
+ * @param {Octokit} client the GitHub client to use that is authenticated as the GitHub installation.
+ * @param {Database} db the Database instance to use to update the PendingPR object if the PR merge fails.
+ * @param {PendingPR} pendingPR the PendingPR object that represents the PR to merge.
+ * @param {string} head the Git commit hash of the head of the PR to merge. If the PR head has changed while the PR was
+ *   being examined by Magic Mirror, the PR won't be merged.
+ * @return {Promise<boolean>} a Promise that resolves to a boolean indicating if the PR was successfully merged.
+ */
+export async function mergePR(client: Octokit, db: Database, pendingPR: PendingPR, head: string): Promise<boolean> {
+  try {
+    await client.pulls.merge({
+      owner: pendingPR.repo.organization,
+      repo: pendingPR.repo.name,
+      pull_number: pendingPR.prID as number,
+      merge_method: "rebase",
+      sha: head,
+    });
+
+    return true;
+  } catch (err) {
+    const issueID = await createFailureIssue(
+      client,
+      pendingPR.repo.organization,
+      pendingPR.repo.name,
+      pendingPR.upstreamRepo.organization,
+      pendingPR.branch,
+      pendingPR.upstreamPRIDs,
+      `the pull-request (#${pendingPR.prID}) couldn't be merged: ${err}`,
+      pendingPR.prID as number,
+    );
+
+    pendingPR.githubIssue = issueID;
+    pendingPR.action = PRAction.Blocked;
+    await db.setPendingPR(pendingPR);
+
+    return false;
+  }
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,9 +1,13 @@
+import { Octokit } from "@octokit/rest";
+import { CheckRunPullRequest, PullRequest } from "@octokit/webhooks-types";
 import { ApplicationFunctionOptions, Probot, Server } from "probot";
 
 import { Config, loadConfig } from "./config";
 import { Database, PRAction } from "./db";
-import { createFailureIssue } from "./github";
+import { createFailureIssue, getRequiredChecks, mergePR } from "./github";
 import { newLogger } from "./log";
+
+const okayCheckRunConclusions = new Set(["success", "neutral", "skipped"]);
 
 /**
  * Add the handlers to Probot app.
@@ -72,105 +76,82 @@ export async function app(probot: Probot, probotOptions: ApplicationFunctionOpti
   });
 
   /**
-   * Handle a completed check suite.
+   * Handle a completed check run.
    *
-   * This handler checks to see if the completed check suite (PR CI) is associated with a PR that Magic Mirror had
-   * previously created. If it is, then Magic Mirror merges the PR if the check suite is successful or if it failed,
-   * a GitHub issue is created. The latter case blocks this forked repo's branch from further syncing by Magic Mirror
-   * until the GitHub issue is closed.
+   * This handler checks to see if the completed check run is associated with a PR that Magic Mirror had
+   * previously created. If it is, then Magic Mirror merges the PR if all the check runs and statuses on the PR are
+   * successful or if it failed, a GitHub issue is created. The latter case blocks this forked repo's branch from
+   * further syncing by Magic Mirror until the GitHub issue is closed.
    */
-  probot.on("check_suite.completed", async (context) => {
-    const check = context.payload.check_suite;
-    const prs = context.payload.check_suite.pull_requests;
+  probot.on("check_run.completed", async (context) => {
+    const check = context.payload.check_run;
+    const prs = context.payload.check_run.pull_requests;
     if (!prs.length) {
-      logger.debug(`Ignoring the check suite #${check.id} since there's no associated PR`);
+      logger.debug(`Ignoring the check run ${check.name} (#${check.id}) since there's no associated PR`);
       return;
     }
 
     const organization = context.payload.repository.owner.login;
-    const repoName = context.payload.repository.name;
-    logger.debug(`Checking the check suite #${check.id} on ${organization}/${repoName}`);
-    const repo = await db.getOrCreateRepo(organization, repoName);
+    const repo = context.payload.repository.name;
+    logger.debug(`Checking the check run ${check.name} (#${check.id}) on ${organization}/${repo}`);
 
+    // It's unlikely that there are multiple PRs with the check run, but stranger things have happened.
     for (const pr of prs) {
-      const pendingPR = await db.getPendingPRByPRID(repo, pr.number);
-      if (!pendingPR) {
-        logger.debug(
-          `The PR #${pr.number} on the check suite #${check.id} on ${organization}/${repoName} does not apply`,
-        );
-        continue;
-      }
-
-      if (pendingPR.action === PRAction.Blocked) {
-        // This can happen if the CI failed initially and a GitHub issue was created for manual action.
-        logger.info(
-          `The PR #${pr.number} on ${organization}/${repoName} is blocked. Skipping to allow for manual action.`,
-        );
-        continue;
-      }
-
-      if (check.conclusion === "success") {
-        logger.debug(`Merging the PR #${pr.number} on ${organization}/${repoName} for the branch ${pr.base.ref}`);
-        try {
-          await context.octokit.pulls.merge({
-            owner: organization,
-            repo: repoName,
-            pull_number: pr.number,
-            merge_method: "rebase",
-            sha: pr.head.sha,
-          });
-        } catch (err) {
-          const issueID = await createFailureIssue(
-            context.octokit,
-            organization,
-            repoName,
-            pendingPR.upstreamRepo.organization,
-            pendingPR.branch,
-            pendingPR.upstreamPRIDs,
-            `the pull-request (#${pr.number}) couldn't be merged: ${err}`,
-            pr.number,
-          );
-
-          logger.info(
-            `Created the GitHub issue #${issueID} on ${organization}/${repoName} to notify of the failure to ` +
-              `merge the PR (#${pr.number}): ${err}`,
-          );
-
-          pendingPR.githubIssue = issueID;
-          pendingPR.action = PRAction.Blocked;
-          await db.setPendingPR(pendingPR);
-
-          return;
-        }
-
-        logger.info(`Merged the PR #${pr.number} on ${organization}/${repoName} for the branch ${pr.base.ref}`);
-        return;
-      }
-
-      logger.info(
-        `The check #${check.id} has the conclusion ${check.conclusion} on PR #${pr.number} on ` +
-          `${organization}/${repoName} for the branch ${pr.base.ref}. Creating a GitHub issue for manual correction.`,
-      );
-      const issueID = await createFailureIssue(
+      const handled = await handlePRCIUpdate(
         context.octokit,
         organization,
-        repoName,
-        pendingPR.upstreamRepo.organization,
-        pendingPR.branch,
-        pendingPR.upstreamPRIDs,
-        `the PR check suite concluded with "${check.conclusion}"`,
-        pr.number,
+        repo,
+        pr,
+        check.name,
+        okayCheckRunConclusions.has(check.conclusion as string),
       );
-      logger.info(`Created the GitHub issue #${issueID} on ${organization}/${repoName} to notify of the failure`);
+      if (handled) {
+        return;
+      }
+    }
 
-      pendingPR.githubIssue = issueID;
-      pendingPR.action = PRAction.Blocked;
-      await db.setPendingPR(pendingPR);
+    logger.debug(`Ignoring the check suite ${check.name} (#${check.id}) since there's not a relevant PR`);
+  });
 
+  /**
+   * Handle a commit status.
+   *
+   * This handler checks to see if the commit status is associated with a PR that Magic Mirror had
+   * previously created. If it is, then Magic Mirror merges the PR if all the check runs and statuses on the PR are
+   * successful or if it failed, a GitHub issue is created. The latter case blocks this forked repo's branch from
+   * further syncing by Magic Mirror until the GitHub issue is closed.
+   */
+  probot.on("status", async (context) => {
+    const status = context.payload;
+    logger.debug(`Checking the commit status ${status.context} on ${status.sha}`);
+
+    if (status.state === "pending") {
+      logger.debug(`Ignoring the commit status ${status.context} on ${status.sha} since it's pending`);
       return;
     }
 
-    logger.debug(`Ignoring the check suite #${check.id} since there's not a relevant PR`);
+    const organization = status.repository.owner.login;
+    const repo = status.repository.name;
+    const prs = await context.octokit.pulls.list({
+      owner: status.repository.owner.login,
+      repo: status.repository.name,
+      head: status.sha,
+    });
+
+    // It's unlikely that there are multiple PRs with the same commit head, but stranger things have happened.
+    for (const pr of prs.data) {
+      const handled = await handlePRCIUpdate(
+        context.octokit,
+        organization,
+        repo,
+        pr,
+        status.context,
+        status.state === "success",
+      );
+      if (handled) {
+        return;
+      }
+    }
   });
 
   /**
@@ -214,6 +195,170 @@ export async function app(probot: Probot, probotOptions: ApplicationFunctionOpti
 
     logger.info(`Marked the PR #${pr.number} as closed on ${organization}/${repoName} for the branch ${pr.base.ref}`);
   });
+
+  /**
+   * Handle a commit status or check run completing for a PR.
+   *
+   * This will merge the PR if this is the last required successful commit status or check run. This will create a
+   * GitHub issue if the commit status or check run failed.
+   *
+   * Note that a PR could get stuck if the required checks on the branch change while the PR CI is still running.
+   *
+   * @param {Octokit} client the GitHub client to use that is authenticated as the GitHub installation.
+   * @param {string} organization the GitHub organization of the repository that the PR belongs to.
+   * @param {string} repoName the GitHub repository name of the repository that the PR belongs to.
+   * @param {PullRequest | CheckRunPullRequest} pr the pull-request that the CI update is for.
+   * @param {string} checkName the name of the commit status or check run that just completed.
+   * @param {boolean} success determines if the commit status or check run was successful.
+   * @return {Promise<boolean>} a Promise that resolves to a boolean indicating if the PR was handled. This is false if
+   *   if the PR is blocked or isn't known to Magic Mirror.
+   */
+  const handlePRCIUpdate = async (
+    client: Octokit,
+    organization: string,
+    repoName: string,
+    pr: PullRequest | CheckRunPullRequest,
+    checkName: string,
+    success: boolean,
+  ): Promise<boolean> => {
+    const repo = await db.getOrCreateRepo(organization, repoName);
+    const pendingPR = await db.getPendingPRByPRID(repo, pr.number);
+    if (!pendingPR) {
+      logger.debug(`The PR #${pr.number} on ${organization}/${repoName} does not apply`);
+      return false;
+    }
+
+    if (pendingPR.action === PRAction.Blocked) {
+      // This can happen if the CI failed initially and a GitHub issue was created for manual action.
+      logger.info(
+        `The PR #${pr.number} on ${organization}/${repoName} is blocked. Skipping to allow for manual action.`,
+      );
+      return false;
+    }
+
+    const requiredChecks = await getRequiredChecks(client, organization, repoName, pr.base.ref);
+    if (!requiredChecks.has(checkName)) {
+      logger.debug(
+        `The check ${checkName} for PR #${pr.number} on ${organization}/${repoName} is not required. Skipping check.`,
+      );
+      return true;
+    }
+
+    // If the check run or status failed, the other check runs and status associated with the PR don't need to be
+    // checked.
+    if (success !== true) {
+      const issueID = await createFailureIssue(
+        client,
+        organization,
+        repoName,
+        pendingPR.upstreamRepo.organization,
+        pendingPR.branch,
+        pendingPR.upstreamPRIDs,
+        "the PR CI failed",
+        pr.number,
+      );
+      logger.info(`Created the GitHub issue #${issueID} on ${organization}/${repoName} to notify of the failure`);
+
+      pendingPR.githubIssue = issueID;
+      pendingPR.action = PRAction.Blocked;
+      await db.setPendingPR(pendingPR);
+
+      return true;
+    }
+
+    const remainingChecks = new Set(requiredChecks);
+
+    // Verify that this is the last required check run/status that we were waiting on.
+    let page = 1;
+    while (true) {
+      const checks = await client.checks.listForRef({
+        owner: organization,
+        repo: repoName,
+        ref: pr.head.ref,
+        page: page,
+      });
+      if (checks.data.check_runs.length === 0) {
+        break;
+      }
+
+      for (const checkRun of checks.data.check_runs) {
+        if (!remainingChecks.has(checkRun.name)) {
+          continue;
+        }
+
+        if (!okayCheckRunConclusions.has(checkRun.conclusion as string)) {
+          logger.debug(
+            `The check run #${checkRun.id} on the PR #${pr.number} on ${organization}/${repoName} has a conclusion ` +
+              `of ${checkRun.conclusion}. Ignoring for now since another webhook event will handle this.`,
+          );
+          return true;
+        }
+
+        remainingChecks.delete(checkRun.name);
+      }
+
+      page += 1;
+    }
+
+    // Skip the commit status API call if the PR CI only uses check runs
+    if (remainingChecks.size) {
+      page = 1;
+      while (true) {
+        const statuses = await client.repos.listCommitStatusesForRef({
+          owner: organization,
+          repo: repoName,
+          ref: pr.head.ref,
+          page: page,
+        });
+        if (statuses.data.length === 0) {
+          break;
+        }
+
+        for (const status of statuses.data) {
+          if (!remainingChecks.has(status.context)) {
+            continue;
+          }
+
+          if (status.state !== "success") {
+            logger.debug(
+              `The commit status #${status.id} on the PR #${pr.number} on ${organization}/${repoName} has a state ` +
+                `of ${status.state}. Ignoring for now since another webhook event will handle this.`,
+            );
+            return true;
+          }
+
+          remainingChecks.delete(status.context);
+        }
+
+        page += 1;
+      }
+    }
+
+    if (remainingChecks.size) {
+      logger.info(
+        `There are still remaining check runs/statuses that aren't registered on the PR #${pr.number} on ` +
+          `${organization}/${repoName}.`,
+      );
+      return true;
+    }
+
+    logger.debug(
+      `All PR CI has passed. Merging the PR #${pr.number} on ${organization}/${repoName} for the branch ${pr.base.ref}`,
+    );
+
+    const merged = await mergePR(client, db, pendingPR, pr.head.sha);
+    if (merged) {
+      logger.info(`Merged the PR #${pr.number} on ${organization}/${repoName} for the branch ${pr.base.ref}`);
+    } else {
+      // The GitHub issue is created in the mergePR function. The log message is here to provide more context.
+      logger.info(
+        `Created a GitHub issue on ${organization}/${repoName} to notify of the failure to merge the PR ` +
+          `(#${pr.number})`,
+      );
+    }
+
+    return true;
+  };
 }
 
 /**


### PR DESCRIPTION
Previous to this commit, if a single check suite passed on the PR, the
PR would be merged. This is incorrect since a check suite only
represents a grouping of check runs by a single GitHub app.

This commit changes Magic Mirror to consider all check runs (created by
GitHub apps) and commit statuses (non-GitHub apps) which are required by
the branch protection configuration. If there are no required check runs
or commit statuses on the branch, Magic Mirror merges the PR right away.