### PR TITLE
Use `magic-mirror-` branch prefix

### DIFF
--- a/src/syncer.ts
+++ b/src/syncer.ts
@@ -405,7 +405,7 @@ export class Syncer {
       await this.db?.deletePendingPR(pendingPR);
     }
 
-    const targetBranch = `${upstreamBranch}-${Date.now()}`;
+    const targetBranch = `magic-mirror-${upstreamBranch}-${Date.now()}`;
     this.logger.info(
       `Creating the "${targetBranch}" branch on ${org}/${repoName} from the following PRs from ` +
         `${upstreamOrg}/${repoName}: ${prIDs.join(", ")}`,


### PR DESCRIPTION
Using the `main-` prefix is used by Prow to signal that the branch should be protected, so adding our own prefix should circumvent this. (Prow uses a `^main-` RegEx.)