### PR TITLE
Set default container for `oc logs`

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       {{- with .Values.podAnnotations }}
       annotations:
+        kubectl.kubernetes.io/default-container: {{ .Chart.Name }}-syncer
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:


### PR DESCRIPTION
I got tired of specifying the container. I've already made this update in Collective.